### PR TITLE
Refactor application to use contexts

### DIFF
--- a/react-app/src/app.tsx
+++ b/react-app/src/app.tsx
@@ -2,12 +2,15 @@ import React from "react";
 
 import { Layout } from "./components/layout";
 import { BPMCalculator } from "./components/bpm-calculator";
+import { ClickTrackProvider } from "./contexts/clicktrack";
 import { PWAProvider } from "./contexts/pwa";
 
 export const App: React.FC = () => (
   <PWAProvider>
     <Layout>
-      <BPMCalculator />
+      <ClickTrackProvider>
+        <BPMCalculator />
+      </ClickTrackProvider>
     </Layout>
   </PWAProvider>
 );

--- a/react-app/src/app.tsx
+++ b/react-app/src/app.tsx
@@ -1,36 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
 import { Layout } from "./components/layout";
 import { BPMCalculator } from "./components/bpm-calculator";
+import { PWAProvider } from "./contexts/pwa";
 
-export interface PWAEvent extends Event {
-  prompt(): Promise<void>;
-}
-
-export const App: React.FC = () => {
-  const [pwaEvt, setPwaEvt] = useState<PWAEvent | undefined>(undefined);
-
-  useEffect(() => {
-    const beforePWAInstall = (event: Event) => {
-      event.preventDefault();
-      setPwaEvt(event as PWAEvent);
-    };
-    window.addEventListener("beforeinstallprompt", beforePWAInstall);
-
-    const afterPWAInstall = () => {
-      setPwaEvt(undefined);
-    };
-    window.addEventListener("appinstalled", afterPWAInstall);
-
-    return () => {
-      window.removeEventListener("beforeinstallprompt", beforePWAInstall);
-      window.removeEventListener("appinstalled", afterPWAInstall);
-    };
-  }, []);
-
-  return (
-    <Layout pwaEvt={pwaEvt}>
+export const App: React.FC = () => (
+  <PWAProvider>
+    <Layout>
       <BPMCalculator />
     </Layout>
-  );
-};
+  </PWAProvider>
+);

--- a/react-app/src/components/bpm-calculator.tsx
+++ b/react-app/src/components/bpm-calculator.tsx
@@ -8,10 +8,9 @@ import { ReactComponent as HalfNoteIcon } from "./half.svg";
 import { ReactComponent as QuarterNoteIcon } from "./quarter.svg";
 import { ReactComponent as SixteenthNoteIcon } from "./sixteenth.svg";
 import { ReactComponent as WholeNoteIcon } from "./whole.svg";
+import { useClickTrackRef } from "../contexts/clicktrack";
 import { ClickTrack } from "../util/clicktrack";
 import { formatDecimal } from "../util/strings";
-
-const clickTrack = new ClickTrack();
 
 function beatNoteToNumber(note: NoteDuration) {
   if (note === "thirtysecondth") {
@@ -30,6 +29,7 @@ function beatNoteToNumber(note: NoteDuration) {
 }
 
 export const BPMCalculator: React.FC = () => {
+  const clickTrack = useClickTrackRef();
   const [bpm, setBpm] = useState<number>(120);
   const [beatsPerMeasure, setBeatsPerMeasure] = useState<number>(4);
   const [beatNote, setBeatNote] = useState<NoteDuration>("quarter");
@@ -37,7 +37,7 @@ export const BPMCalculator: React.FC = () => {
 
   const bpmCalculator = new BPM(bpm);
 
-  clickTrack.setBPM(bpm);
+  clickTrack.current.setBPM(bpm);
 
   const notes = [
     {
@@ -202,7 +202,7 @@ export const BPMCalculator: React.FC = () => {
               onClick={() => {
                 const result = beatsPerMeasure + 1;
                 setBeatsPerMeasure(result);
-                clickTrack.setBeatsPerMeasure(result);
+                clickTrack.current.setBeatsPerMeasure(result);
               }}
             >
               <ArrowIcon className="arrow" />
@@ -215,7 +215,7 @@ export const BPMCalculator: React.FC = () => {
                 const result = beatsPerMeasure - 1;
                 if (result >= ClickTrack.MIN_BEATS_PER_MEASURE) {
                   setBeatsPerMeasure(result);
-                  clickTrack.setBeatsPerMeasure(result);
+                  clickTrack.current.setBeatsPerMeasure(result);
                 }
               }}
               style={{ marginTop: "5px" }}
@@ -328,16 +328,17 @@ export const BPMCalculator: React.FC = () => {
 };
 
 const Beeper: React.FC = () => {
+  const clickTrack = useClickTrackRef();
   const [currentBeat, setCurrentBeat] = useState<number>(1);
 
   // hook that updates currentBeat whenever the Metronome ticks. Must ensure
   // this hook has zero dependencies so that the callback only gets
   // registered once.
   useEffect(() => {
-    clickTrack.addClickCallback(({ currentBeat }) =>
+    clickTrack.current.addClickCallback(({ currentBeat }) =>
       setCurrentBeat(currentBeat)
     );
-  }, []);
+  }, [clickTrack]);
 
   return (
     <span
@@ -353,6 +354,7 @@ const Beeper: React.FC = () => {
 };
 
 const PlaybackBtn: React.FC = () => {
+  const clickTrack = useClickTrackRef();
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
 
   return (
@@ -363,11 +365,11 @@ const PlaybackBtn: React.FC = () => {
       }`}
       onClick={() => {
         if (isPlaying) {
-          clickTrack.stop();
+          clickTrack.current.stop();
           return setIsPlaying(false);
         }
 
-        clickTrack.start().then(() => {
+        clickTrack.current.start().then(() => {
           setIsPlaying(true);
         });
       }}

--- a/react-app/src/components/layout.tsx
+++ b/react-app/src/components/layout.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 
-import { PWAEvent } from "../app";
 import "./layout.css";
+import { usePWA } from "../contexts/pwa";
 
-interface Props {
-  pwaEvt: PWAEvent | undefined;
-}
-
-export const Layout: React.FC<Props> = ({ children, pwaEvt }) => {
+export const Layout: React.FC = ({ children }) => {
+  const pwaEvt = usePWA();
   return (
     <>
       <header className="header">

--- a/react-app/src/contexts/clicktrack.tsx
+++ b/react-app/src/contexts/clicktrack.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useRef } from "react";
+import { ClickTrack } from "../util/clicktrack";
+
+/** Singleton ClickTrack */
+const clickTrack = new ClickTrack();
+
+const ClickTrackContext = createContext<ClickTrack>(clickTrack);
+
+export const useClickTrackRef = () => {
+  const context = useContext(ClickTrackContext);
+  return useRef(context);
+};
+
+export const ClickTrackProvider: React.FC = ({ children }) => {
+  return (
+    <ClickTrackContext.Provider value={clickTrack}>
+      {children}
+    </ClickTrackContext.Provider>
+  );
+};

--- a/react-app/src/contexts/pwa.tsx
+++ b/react-app/src/contexts/pwa.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+interface PWAEvent extends Event {
+  prompt(): Promise<void>;
+}
+
+const PWAContext = createContext<PWAEvent | undefined>(undefined);
+
+export const usePWA = () => useContext(PWAContext);
+
+export const PWAProvider: React.FC = ({ children }) => {
+  const [pwaEvt, setPwaEvt] = useState<PWAEvent | undefined>(undefined);
+
+  useEffect(() => {
+    const beforePWAInstall = (event: Event) => {
+      event.preventDefault();
+      setPwaEvt(event as PWAEvent);
+    };
+    window.addEventListener("beforeinstallprompt", beforePWAInstall);
+
+    const afterPWAInstall = () => {
+      setPwaEvt(undefined);
+    };
+    window.addEventListener("appinstalled", afterPWAInstall);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", beforePWAInstall);
+      window.removeEventListener("appinstalled", afterPWAInstall);
+    };
+  }, []);
+
+  return <PWAContext.Provider value={pwaEvt}>{children}</PWAContext.Provider>;
+};


### PR DESCRIPTION
# Summary

Currently, the applications has 2 globals:

- The `window` event `"beforeinstallprompt"`
- ToneJS's audio context singleton

## Details

- [x] `"beforeinstallprompt"`
- [x] ToneJS