### PR TITLE
Run publish-gh on react-app releases

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,13 +1,14 @@
 name: Publish to GH Pages
 
 on:
-  push:
-    branches: [master]
+  release:
+    types: [published]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
+    if: contains(github.ref, "react-app")
     steps:
       - uses: actions/checkout@v2
         name: Checkout


### PR DESCRIPTION
# Summary

Updates the `publish-gh-pages` action to only run on published releases for `@vapurrmaid/bpm-react-app`. It's hard to explicitly verify that the `contains` function will work as expected, so will have to keep an eye out.